### PR TITLE
add SetOutput() method to customize output location

### DIFF
--- a/colorine.go
+++ b/colorine.go
@@ -42,6 +42,7 @@ func (logger *Logger) getOutput() io.Writer {
 func (logger *Logger) SetOutput(w io.Writer) {
 	logger.mu.Lock()
 	defer logger.mu.Unlock()
+	ct.Writer = w
 	logger.output = w
 }
 
@@ -115,6 +116,11 @@ func (logger *Logger) Log(prefix, message string) {
 		}
 	}
 
+	out := logger.getOutput()
+
+	logger.mu.Lock()
+	defer logger.mu.Unlock()
+
 	ct.ChangeColor(
 		textStyle.Foreground.Color,
 		textStyle.Foreground.Bright,
@@ -122,10 +128,6 @@ func (logger *Logger) Log(prefix, message string) {
 		textStyle.Background.Bright,
 	)
 
-	out := logger.getOutput()
-
-	logger.mu.Lock()
-	defer logger.mu.Unlock()
 	fmt.Fprintf(out, "%10s", prefix)
 
 	ct.ResetColor()

--- a/colorine.go
+++ b/colorine.go
@@ -14,6 +14,8 @@ package colorine
 
 import (
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/daviddengcn/go-colortext"
 )
@@ -22,6 +24,19 @@ import (
 type Logger struct {
 	// Prefix string to TextStyle mapping.
 	Prefixes Prefixes
+	output   io.Writer
+}
+
+func (logger *Logger) getOutput() io.Writer {
+	if logger.output == nil {
+		logger.output = os.Stdout
+	}
+	return logger.output
+}
+
+// SetOutput sets the output destination for the logger.
+func (logger *Logger) SetOutput(w io.Writer) {
+	logger.output = w
 }
 
 // A TextStyle represents the style that strings are displayed with. Consists
@@ -80,7 +95,7 @@ var (
 // By default, no prefix is registered to any text style.
 func NewLogger(prefixes Prefixes, defaultStyle TextStyle) *Logger {
 	prefixes[""] = defaultStyle
-	return &Logger{prefixes}
+	return &Logger{Prefixes: prefixes, output: os.Stdout}
 }
 
 // Log prints messages to console. prefix is colored using the logger.prefixes
@@ -101,9 +116,10 @@ func (logger *Logger) Log(prefix, message string) {
 		textStyle.Background.Bright,
 	)
 
-	fmt.Printf("%10s", prefix)
+	out := logger.getOutput()
+	fmt.Fprintf(out, "%10s", prefix)
 
 	ct.ResetColor()
 
-	fmt.Printf(" %s\n", message)
+	fmt.Fprintf(out, " %s\n", message)
 }


### PR DESCRIPTION
Since I want to output logs to STDERR, I added a `SetOutput` method that can change the output destination.

I also added mutex for thread safe.

I think it is not a good behavior that logger logs to STDOUT by default, but keep it for backward compatibility.